### PR TITLE
Feature: allow filtering immutable collection

### DIFF
--- a/index.js
+++ b/index.js
@@ -60,7 +60,7 @@ export function createBlacklistFilter(reducerName, inboundPaths, outboundPaths) 
 function filterObject({path, filterFunction = () => true}, state, iterable) {
     const value = iterable ? state.getIn(path) : get(state, path);
     
-    return Array.isArray(value) ? value.filter(filterFunction) : pickBy(value, filterFunction);
+    return (Array.isArray(value) || Iterable.isIterable(value)) ? value.filter(filterFunction) : pickBy(value, filterFunction);
 }
 
 


### PR DESCRIPTION
Hello,

in the `filterObject` function when the `value` is an Immutable object the filter function is not correctly applied.
 
You assume that `value` is a simple Javascript object but if `value` is an Immutable object the check `Array.isArray(value)` return false and the function`-.pickBy` is used. Unfortunately it  doesn't operate on Immutable collection.

My idea is instead to use the `Immutable.filter` function that operate on Immutable collections.