### PR TITLE
Added a feature to pass array of reducer names

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -5,9 +5,9 @@ declare module "redux-persist-transform-filter-immutable" {
     type TransformType = 'whitelist' | 'blacklist';
     
     
-    export function createFilter<State, Raw>(reducerName: string, inboundPaths?: string[], outboundPaths?: string[], transformType?: TransformType): Transform<State, Raw>;
-    export function createWhitelistFilter<State, Raw>(reducerName: string, inboundPaths?: string[], outboundPaths?: string[]): Transform<State, Raw>;
-    export function createBlacklistFilter<State, Raw>(reducerName: string, inboundPaths?: string[], outboundPaths?: string[]): Transform<State, Raw>;
+    export function createFilter<State, Raw>(reducerName: string | string[], inboundPaths?: string[], outboundPaths?: string[], transformType?: TransformType): Transform<State, Raw>;
+    export function createWhitelistFilter<State, Raw>(reducerName: string | string, inboundPaths?: string[], outboundPaths?: string[]): Transform<State, Raw>;
+    export function createBlacklistFilter<State, Raw>(reducerName: string | string, inboundPaths?: string[], outboundPaths?: string[]): Transform<State, Raw>;
     export function persistFilter<State, Raw>(state: State, paths: string[], transformType: TransformType): Transform<State, Raw>;
     
     

--- a/index.js
+++ b/index.js
@@ -42,7 +42,7 @@ export function createFilter(reducerName, inboundPaths, outboundPaths, transform
     return createTransform(
         (inboundState, key) => inboundPaths ? persistFilter(inboundState, inboundPaths, transformType) : inboundState,
         (outboundState, key) => outboundPaths ? persistFilter(outboundState, outboundPaths, transformType) : outboundState,
-        {whitelist:  typeof reducerName === "string"?  [reducerName]: reducerName}
+        {[transformType]: 'string' === typeof reducerName ?  [reducerName] : reducerName}
     );
 };
 

--- a/index.js
+++ b/index.js
@@ -42,7 +42,7 @@ export function createFilter(reducerName, inboundPaths, outboundPaths, transform
     return createTransform(
         (inboundState, key) => inboundPaths ? persistFilter(inboundState, inboundPaths, transformType) : inboundState,
         (outboundState, key) => outboundPaths ? persistFilter(outboundState, outboundPaths, transformType) : outboundState,
-        {whitelist: [reducerName]}
+        {whitelist:  typeof reducerName === "string"?  [reducerName]: reducerName}
     );
 };
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
-    "name":             "@actra-development-oss/redux-persist-transform-filter-immutable",
-    "description":      "Filter transformator for redux-persist supporting immutable.js",
-    "keywords":         [
+    "name": "@actra-development-oss/redux-persist-transform-filter-immutable",
+    "description": "Filter transformator for redux-persist supporting immutable.js",
+    "keywords": [
         "react",
         "redux",
         "redux-persist",
@@ -10,64 +10,63 @@
         "filter",
         "immutable"
     ],
-    "license":          "MIT",
-    "version":          "0.2.1",
-    "author":           {
-        "name":  "Gabriel Schuster - actra.development",
+    "license": "MIT",
+    "version": "0.2.1",
+    "author": {
+        "name": "Gabriel Schuster - actra.development",
         "email": "opensource@actra.de",
-        "url":   "http://www.actra.de/velopment"
+        "url": "http://www.actra.de/velopment"
     },
-    "homepage":         "https://github.com/actra-development-oss/redux-persist-transform-filter-immutable#readme",
-    "repository":       {
+    "homepage": "https://github.com/actra-development-oss/redux-persist-transform-filter-immutable#readme",
+    "repository": {
         "type": "git",
-        "url":  "git@github.com:actra-development-oss/redux-persist-transform-filter-immutable.git"
+        "url": "git@github.com:actra-development-oss/redux-persist-transform-filter-immutable.git"
     },
-    "bugs":             {
-        "url":   "https://github.com/actra-development-oss/redux-persist-transform-filter-immutable/issues",
+    "bugs": {
+        "url": "https://github.com/actra-development-oss/redux-persist-transform-filter-immutable/issues",
         "email": "opensource@actra.de"
     },
-    "publishConfig":    {
+    "publishConfig": {
         "registry": "https://registry.npmjs.com/",
-        "access":   "public"
+        "access": "public"
     },
-    "dependencies":     {
-        "immutable":          "^3.8.2",
-        "lodash.forin":       "^4.4.0",
-        "lodash.get":         "^4.4.2",
-        "lodash.includes":    "^4.3.0",
-        "lodash.isempty":     "^4.4.0",
-        "lodash.isobject":    "^3.0.2",
-        "lodash.isstring":    "^4.0.1",
+    "dependencies": {
+        "immutable": "^3.8.2",
+        "lodash.forin": "^4.4.0",
+        "lodash.get": "^4.4.2",
+        "lodash.includes": "^4.3.0",
+        "lodash.isempty": "^4.4.0",
+        "lodash.isobject": "^3.0.2",
+        "lodash.isstring": "^4.0.1",
         "lodash.isundefined": "^3.0.1",
-        "lodash.pickby":      "^4.6.0",
-        "lodash.set":         "^4.3.2",
-        "lodash.unset":       "^4.5.2"
+        "lodash.pickby": "^4.6.0",
+        "lodash.set": "^4.3.2",
+        "lodash.unset": "^4.5.2"
     },
-    "devDependencies":  {
-        "babel-cli":           "^6.26.0",
+    "devDependencies": {
+        "babel-cli": "^6.26.0",
         "babel-preset-es2015": "^6.24.1",
-        "babel-register":      "^6.26.0",
-        "chai":                "^4.1.2",
-        "mocha":               "^4.0.1",
-        "mkdirp":              "^0.5.1",
-        "redux":               "^3.7.2",
-        "rimraf":              "^2.6.1"
+        "babel-register": "^6.26.0",
+        "chai": "^4.1.2",
+        "mocha": "^4.0.1",
+        "mkdirp": "^0.5.1",
+        "redux": "^3.7.2",
+        "rimraf": "^2.6.1"
     },
     "peerDependencies": {
         "immutable": "^3.8.2"
     },
-    "files":            [
+    "files": [
         "dist"
     ],
-    "main":             "dist/index.js",
-    "scripts":          {
-        "test":    "npm run-script mocha -- --require babel-register spec.js",
-        "build":   "npm run-script rimraf -- ./dist && npm run-script mkdirp -- dist && npm run-script babel -- index.js -o dist/index.js",
+    "main": "dist/index.js",
+    "scripts": {
+        "test": "npm run-script mocha -- --require babel-register spec.js",
+        "build": "npm run-script rimraf -- ./dist && npm run-script mkdirp -- dist && npm run-script babel -- index.js -o dist/index.js",
         "release": "npm run-script test && npm run-script build && npm publish --access public",
-        
-        "babel":  "./node_modules/.bin/babel",
+        "babel": "./node_modules/.bin/babel",
         "mkdirp": "./node_modules/.bin/mkdirp",
-        "mocha":  "./node_modules/.bin/mocha",
+        "mocha": "./node_modules/.bin/mocha",
         "rimraf": "./node_modules/.bin/rimraf"
     }
 }

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
         "immutable"
     ],
     "license": "MIT",
-    "version": "0.2.1",
+    "version": "0.2.2",
     "author": {
         "name": "Gabriel Schuster - actra.development",
         "email": "opensource@actra.de",

--- a/spec.js
+++ b/spec.js
@@ -62,7 +62,7 @@ describe('redux-persist-transform-filter', () => {
             expect(persistFilter(JSON.parse(JSON.stringify(store)), [{ path: 'a', filterFunction: item => item.x }], 'blacklist')).to.deep.equal({a:{'id3':{x:false, b:'bbb'}}, d:'d'});
             expect(persistFilter(JSON.parse(JSON.stringify(store)), [{ path: 'a', filterFunction: item => item.b === 'bb' }], 'blacklist')).to.deep.equal({a:{'id1':{x:true, b:'b'}, 'id3':{x:false, b:'bbb'}}, d:'d'});
         });
-        
+
         it('should return a subset, given an object that contains a path and a filterFunction to reduce array', () => {
             const store = {a:[1,2,3], b:'b'};
             expect(persistFilter(JSON.parse(JSON.stringify(store)), [{ path: 'a', filterFunction: () => true }], 'blacklist')).to.deep.equal({a:[], b:'b'});
@@ -78,6 +78,16 @@ describe('redux-persist-transform-filter', () => {
 
         it('should return an object with in, out, transformDataToStorage and transformDataFromStorage functions', () => {
             const myFilter = createFilter('reducerName', 'a.b', 'a.c');
+            expect(myFilter).to.be.an('object');
+            expect(myFilter).to.have.all.keys(['in', 'out', 'transformDataToStorage', 'transformDataFromStorage']);
+            expect(myFilter.in).to.be.a('function');
+            expect(myFilter.out).to.be.a('function');
+            expect(myFilter.transformDataToStorage).to.be.a('function');
+            expect(myFilter.transformDataFromStorage).to.be.a('function');
+        });
+
+        it('reducersName as array - should return an object with in, out, transformDataToStorage and transformDataFromStorage functions', () => {
+            const myFilter = createFilter(['reducerName', 'otherReducerName'], 'a.b', 'a.c');
             expect(myFilter).to.be.an('object');
             expect(myFilter).to.have.all.keys(['in', 'out', 'transformDataToStorage', 'transformDataFromStorage']);
             expect(myFilter.in).to.be.a('function');


### PR DESCRIPTION
Instead of this:
```js
const saveSubsetBlacklistFilter = createBlacklistFilter(
    'myReducerOne',
    ['keyYouDontWantToSave1']
);

const saveOtherSubsetBlacklistFilter= createBlacklistFilter(
    'myReducerTwo',
    ['keyYouDontWantToSave1']
);

persistStore(store, {
    transforms: [
        saveSubsetBlacklistFilter,
        saveOtherSubsetBlacklistFilter,
    ]
});
```
now possible the following:
```js
const saveSubsetBlacklistFilter= createBlacklistFilter(
    ['myReducerTwo',  'myReducerOne']
    ['keyYouDontWantToSave1']
);

persistStore(store, {
    transforms: [
        saveSubsetBlacklistFilter
    ]
});
```

What do you think?